### PR TITLE
Increase VMMS max capacity to 600

### DIFF
--- a/lansa-vmss-windows-autoscale-sql-database/createUiDefinition.json
+++ b/lansa-vmss-windows-autoscale-sql-database/createUiDefinition.json
@@ -121,24 +121,24 @@
                 "name": "minimumInstanceCount",
                 "type": "Microsoft.Common.TextBox",
                 "label": "Minimum Instance Count",
-                "toolTip": "Minimum number of Virtual Machine instances (1 or more).",
+                "toolTip": "Minimum number of Virtual Machine instances (1 to 600).",
                 "defaultValue": "[int('1')]",
                 "constraints": {
                     "required": true,
-                    "regex": "^[1-9][0-9]?$|^100$",
-                    "validationMessage": "Only numerals are allowed. The value must be from 1-100."
+                    "regex": "^[1-9][0-9]?$|^[1-5][0-9][0-9]?$|^600$",
+                    "validationMessage": "Only numerals are allowed. The value must be from 1-600."
                 }
             },
             {
                 "name": "maximumInstanceCount",
                 "type": "Microsoft.Common.TextBox",
                 "label": "Maximum Instance Count",
-                "toolTip": "Maximum number of Virtual Machine instances (100 or less).",
+                "toolTip": "Maximum number of Virtual Machine instances (1 to 600).",
                 "defaultValue": "[int('100')]",
                 "constraints": {
                     "required": true,
-                    "regex": "^[1-9][0-9]?$|^100$",
-                    "validationMessage": "Only numerals are allowed. The value must be from 1-100."
+                    "regex": "^[1-9][0-9]?$|^[1-5][0-9][0-9]?$|^600$",
+                    "validationMessage": "Only numerals are allowed. The value must be from 1-600."
                 }
             },
             {

--- a/lansa-vmss-windows-autoscale-sql-database/mainTemplate.json
+++ b/lansa-vmss-windows-autoscale-sql-database/mainTemplate.json
@@ -142,7 +142,7 @@
             "description": "Minimum number of Virtual Machine instances (1 or more)."
          },
          "minValue": 1,
-         "maxValue": 100
+         "maxValue": 600
       },
       "maximumInstanceCount": {
          "type": "int",
@@ -151,7 +151,7 @@
             "description": "Maximum number of Virtual Machine instances (100 or less)."
          },
          "minValue": 1,
-         "maxValue": 100
+         "maxValue": 600
       },
       "databaseNewOrExisting": {
         "type": "string",
@@ -486,8 +486,11 @@
          "name": "[variables('publicIPAddressName')]",
          "location": "[parameters('location')]",
          "apiVersion": "2019-08-01",
+         "sku": {
+            "name": "[if(lessOrEquals(parameters('maximumInstanceCount'), 100), 'Basic', 'Standard')]"
+         },
          "properties": {
-            "publicIPAllocationMethod": "Dynamic",
+            "publicIPAllocationMethod": "[if(lessOrEquals(parameters('maximumInstanceCount'), 100), 'Dynamic', 'Static')]",
             "dnsSettings": {
                "domainNameLabel": "[variables('longNamingInfix')]"
             }
@@ -498,6 +501,9 @@
          "name": "[variables('loadBalancerName')]",
          "location": "[parameters('location')]",
          "apiVersion": "2019-08-01",
+         "sku": {
+            "name": "[if(lessOrEquals(parameters('maximumInstanceCount'), 100), 'Basic', 'Standard')]"
+         },
          "dependsOn": [
             "[ResourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
          ],
@@ -739,6 +745,7 @@
          },
          "plan": "[if(variables('isCustomImage'), json('null'), variables('imagePlan'))]",
          "properties": {
+            "singlePlacementGroup": "[lessOrEquals(parameters('maximumInstanceCount'), 100)]",
             "overprovision": false,
             "upgradePolicy": {
                "mode": "Automatic"

--- a/lansa-vmss-windows-autoscale-sql-database/mainTemplate.json
+++ b/lansa-vmss-windows-autoscale-sql-database/mainTemplate.json
@@ -139,7 +139,7 @@
          "type": "int",
          "defaultValue": 1,
          "metadata": {
-            "description": "Minimum number of Virtual Machine instances (1 or more)."
+            "description": "Minimum number of Virtual Machine instances (1 to 600)."
          },
          "minValue": 1,
          "maxValue": 600
@@ -148,7 +148,7 @@
          "type": "int",
          "defaultValue": 100,
          "metadata": {
-            "description": "Maximum number of Virtual Machine instances (100 or less)."
+            "description": "Maximum number of Virtual Machine instances (1 to 600)."
          },
          "minValue": 1,
          "maxValue": 600


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Added check to create a standard load balancer and configuring a standard pip when the maximum instance count > 100
* The default value of max instance count is still set to 100. Can be up to 600.
* CreateUiDefinition file updated with appropriate regex for the new range.
