### PR TITLE
Supporting PR (for conversion of `Cloud Account Id Image Release` to `Publish Cloud Account Id Images 3.0`)

### DIFF
--- a/lansa-vmss-windows-autoscale-sql-database/DatabaseDeploymentTemplates/sqlServerTemplate.json
+++ b/lansa-vmss-windows-autoscale-sql-database/DatabaseDeploymentTemplates/sqlServerTemplate.json
@@ -212,7 +212,7 @@
             "dependsOn": [
                 "managedDiskResources",
                 "[concat('Microsoft.Network/networkInterfaces/', parameters('networkInterfaceName'))]",
-                "[concat('Microsoft.Storage/storageAccounts/', parameters('diagnosticsStorageAccountName'))]"
+                "[concat('Microsoft.Storage/storageAccounts/', toLower(parameters('diagnosticsStorageAccountName')))]"
             ],
             "properties": {
                 "hardwareProfile": {

--- a/lansa-vmss-windows-autoscale-sql-database/DatabaseDeploymentTemplates/sqlServerTemplate.json
+++ b/lansa-vmss-windows-autoscale-sql-database/DatabaseDeploymentTemplates/sqlServerTemplate.json
@@ -269,13 +269,13 @@
                 "diagnosticsProfile": {
                     "bootDiagnostics": {
                         "enabled": true,
-                        "storageUri": "[concat('https://', parameters('diagnosticsStorageAccountName'), '.blob.core.windows.net/')]"
+                        "storageUri": "[concat('https://', toLower(parameters('diagnosticsStorageAccountName')), '.blob.core.windows.net/')]"
                     }
                 }
             }
         },
         {
-            "name": "[parameters('diagnosticsStorageAccountName')]",
+            "name": "[toLower(parameters('diagnosticsStorageAccountName'))]",
             "type": "Microsoft.Storage/storageAccounts",
             "apiVersion": "2019-06-01",
             "location": "[parameters('location')]",


### PR DESCRIPTION
The storage params needed to be converted `toLower`

Context: For the pipeline in question (https://dev.azure.com/VisualLansa/Lansa%20Azure%20Scalable%20License%20Images/_build?definitionId=69&_a=summary) to run correctly, the storage params have to be converted to lowercase, which is the (only) modification made in the file.